### PR TITLE
Incluir archivos para ejecutar el proyecto en Docker

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -8,4 +8,5 @@ NODE_ENV="dev"
 # Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
-DATABASE_URL="mongodb+srv://Esarac:Minecraft03.@cluster0.ibwulqn.mongodb.net/dev"
+# DATABASE_URL="mongodb+srv://Esarac:Minecraft03.@cluster0.ibwulqn.mongodb.net/dev"
+DATABASE_URL="mongodb://root:example@mongo:27017/dev"

--- a/.env.test
+++ b/.env.test
@@ -8,4 +8,4 @@ NODE_ENV="test"
 # Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
-DATABASE_URL="mongodb+srv://Esarac:Minecraft03.@cluster0.ibwulqn.mongodb.net/test"
+DATABASE_URL="mongodb://root:example@mongo:27017/test"

--- a/build-and-run.cmd
+++ b/build-and-run.cmd
@@ -1,0 +1,23 @@
+echo "Creando volumen para el almacenamiento persistente"
+docker volume create mongo-data
+
+echo "Detiene servicios en ejecución"
+docker rm -f mongo
+docker rm -f mongo-express
+
+echo "Ejecuta mongo"
+docker run -d --name mongo ^
+    -p 27017:27017 ^
+    -e MONGO_INITDB_ROOT_USERNAME=root ^
+    -e MONGO_INITDB_ROOT_PASSWORD=example ^
+    -v mongo-data:/data/db ^
+    mongo:6.0.2 
+
+echo "Ejecuta mongo-express (administración web)"
+docker run -d --name mongo-express ^
+    --link mongo ^
+    -p 8081:8081 ^
+    -e ME_CONFIG_MONGODB_ADMINUSERNAME=root ^
+    -e ME_CONFIG_MONGODB_ADMINPASSWORD=example ^
+    -e ME_CONFIG_MONGODB_URL=mongodb://root:example@mongo:27017/ ^
+    mongo-express:latest

--- a/build-and-run.sh
+++ b/build-and-run.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+echo "Creando volumen para el almacenamiento persistente"
+docker volume create mongo-data || true
+
+echo "\n"
+echo "Detiene servicios en ejecución"
+docker rm -f mongo || true
+docker rm -f mongo-express || true
+
+echo "\n"
+echo "Ejecuta mongo"
+docker run -d --name mongo \
+    -p 27017:27017 \
+    -e MONGO_INITDB_ROOT_USERNAME=root \
+    -e MONGO_INITDB_ROOT_PASSWORD=example \
+    -v mongo-data:/data/db \
+    -v ./mongo-init:/docker-entrypoint-initdb.d/ \
+    mongo:6.0.2 
+
+# NOTA: - al exponer el puerto, mongo esta disponible en localhost:27017
+
+echo "\n"
+echo "Ejecuta mongo-express (administración web)"
+docker run -d --name mongo-express \
+    --link mongo \
+    -p 8081:8081 \
+    -e ME_CONFIG_MONGODB_ADMINUSERNAME=root \
+    -e ME_CONFIG_MONGODB_ADMINPASSWORD=example \
+    -e ME_CONFIG_MONGODB_URL=mongodb://root:example@mongo:27017/ \
+    mongo-express:latest
+
+# NOTA: - mongo-express queda disponible en localhost:8081
+#       - se crea el contenedor con "link" al contenedor "mongo"

--- a/create-databases.cmd
+++ b/create-databases.cmd
@@ -1,0 +1,8 @@
+echo "Crea bases de datos"
+docker exec -it mongo ^
+    mongosh -u root -p example ^
+    --eval "db = db.getSiblingDB('dev'); db.createCollection('dummy');"
+
+docker exec -it mongo ^
+    mongosh -u root -p example ^
+    --eval "db = db.getSiblingDB('test'); db.createCollection('dummy');"

--- a/create-databases.sh
+++ b/create-databases.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+echo "Crea bases de datos"
+docker exec -it mongo \
+    mongosh -u root -p example \
+    --eval "db = db.getSiblingDB('dev'); db.createCollection('dummy');"
+
+docker exec -it mongo \
+    mongosh -u root -p example \
+    --eval "db = db.getSiblingDB('test'); db.createCollection('dummy');"

--- a/delete-containers.cmd
+++ b/delete-containers.cmd
@@ -1,0 +1,3 @@
+echo "Detiene servicios en ejecución"
+docker rm -f mongo
+docker rm -f mongo-express

--- a/delete-containers.sh
+++ b/delete-containers.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "Detiene servicios en ejecución"
+docker rm -f mongo || true
+docker rm -f mongo-express || true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+# Contenedores para el proyecto
+# NOTA: usa root/example como credenciales user/password
+version: '3.1'
+
+# servicios
+services:
+
+  mongo:
+    container_name: mongo
+    image: mongo
+    restart: always
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: example
+    volumes:
+      - mongo-data:/data/db
+
+  mongo-express:
+    container_name: mongo-express
+    image: mongo-express
+    restart: always
+    ports:
+      - 8081:8081
+    environment:
+      ME_CONFIG_MONGODB_ADMINUSERNAME: root
+      ME_CONFIG_MONGODB_ADMINPASSWORD: example
+      ME_CONFIG_MONGODB_URL: mongodb://root:example@mongo:27017/
+
+# Almacenamiento en disco
+volumes:
+  mongo-data:


### PR DESCRIPTION
Incluye archivos para ejecutar mongodb y mongo-express usando docker y ejecutar el back-end sin necesidad de Mongo Atlas.

## Ejecutando usando docker

Para ejecutar los contenedores se puede ejecutar `build-and-run-sh`. Las base de datos `dev` y ` test` se pueden crear usando `create-databases.sh`

```
# ejecuta los contenedores
./build-and-run.sh

# crea la base de datos
./create-databases.sh

# detiene y elimina los contenedores
./delete-containers.sh
```

## Ejecutando usando Docker Compose

En Visual Studio y Gitpod es posible hacer clic derecho sobre el archivo `docker-compose.yml` e iniciar los servicios. Es posible iniciar los servicios usando el comando `docker-compose` 

```
# inicia los servicios
docker-compose up

# detiene los servicios
docker-compose down
```
